### PR TITLE
Use Wants and PartOf for inter-container dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,15 @@ podluck_pod_state: present
 # stopped.
 podluck_pod_containers: []
 
-# Optional: Mapping of dependencies where keys are container names, and values
-# are lists of container names which need to be started before.
-podluck_pod_dependencies: {}
+# Optional: List of dependency entries with container and wants keys:
+#     podluck_pod_dependencies:
+#       -
+#         container: container-name
+#         wants: other-container-name
+#       -
+#         container: other-container-name
+#         wants: some-additional-container-name
+podluck_pod_dependencies: []
 
 # Optional: Systemd scope (either 'system' or 'user')
 podluck_systemd_scope: system

--- a/roles/podluck_pod_systemd/README.md
+++ b/roles/podluck_pod_systemd/README.md
@@ -47,9 +47,15 @@ podluck_pod_state: present
 # stopped.
 podluck_pod_containers: []
 
-# Optional: Mapping of dependencies where keys are container names, and values
-# are lists of container names which need to be started before.
-podluck_pod_dependencies: {}
+# Optional: List of dependency entries with container and wants keys:
+#     podluck_pod_dependencies:
+#       -
+#         container: container-name
+#         wants: other-container-name
+#       -
+#         container: other-container-name
+#         wants: some-additional-container-name
+podluck_pod_dependencies: []
 
 # Optional: Systemd scope (either 'system' or 'user')
 podluck_systemd_scope: system

--- a/roles/podluck_pod_systemd/defaults/main.yml
+++ b/roles/podluck_pod_systemd/defaults/main.yml
@@ -14,9 +14,15 @@ podluck_pod_state: present
 # stopped.
 podluck_pod_containers: []
 
-# Optional: Mapping of dependencies where keys are container names, and values
-# are lists of container names which need to be started before.
-podluck_pod_dependencies: {}
+# Optional: List of dependency entries with container and wants keys:
+#     podluck_pod_dependencies:
+#       -
+#         container: container-name
+#         wants: other-container-name
+#       -
+#         container: other-container-name
+#         wants: some-additional-container-name
+podluck_pod_dependencies: []
 
 # Optional: Systemd scope (either 'system' or 'user')
 podluck_systemd_scope: system

--- a/roles/podluck_pod_systemd/tasks/dependencies_absent.yml
+++ b/roles/podluck_pod_systemd/tasks/dependencies_absent.yml
@@ -2,13 +2,11 @@
 - name: Required variables defined
   assert:
     that:
-      - podluck_container_name is defined
-      - podluck_container_dependencies is defined
+      - podluck_pod_dependency is defined
+      - podluck_pod_dependency.container is defined
+      - podluck_pod_dependency.wants is defined
 
 - name: Podluck container dependency absent
-  loop: "{{ podluck_container_dependencies }}"
-  loop_control:
-    loop_var: podluck_container_bind_name
   file:
-    path: "{{ podluck_systemd_config_dir }}/{{ podluck_pod_name }}@{{ podluck_container_name }}.service.d/bind-to-{{ podluck_container_bind_name }}.conf"
+    path: "{{ podluck_systemd_config_dir }}/{{ podluck_pod_name }}@{{ podluck_pod_dependency.container }}.service.d/wants-{{ podluck_pod_dependency.wants }}.conf"
     state: absent

--- a/roles/podluck_pod_systemd/tasks/dependencies_present.yml
+++ b/roles/podluck_pod_systemd/tasks/dependencies_present.yml
@@ -2,29 +2,28 @@
 - name: Required variables defined
   assert:
     that:
-      - podluck_container_name is defined
-      - podluck_container_dependencies is defined
+      - podluck_pod_dependency is defined
+      - podluck_pod_dependency.container is defined
+      - podluck_pod_dependency.wants is defined
 
 - name: Podluck container systemd override directory present
   tags:
     - configuration
   file:
     state: directory
-    path: "{{ podluck_systemd_config_dir }}/{{ podluck_pod_name }}@{{ podluck_container_name }}.service.d"
+    path: "{{ podluck_systemd_config_dir }}/{{ podluck_pod_name }}@{{ podluck_pod_dependency.container }}.service.d"
     owner: "{{ podluck_systemd_override_dir_owner | default(omit) }}"
     group: "{{ podluck_systemd_override_dir_group | default(omit) }}"
     mode: "{{ podluck_systemd_override_dir_mode }}"
 
 - name: Podluck container dependency present
-  loop: "{{ podluck_container_dependencies }}"
-  loop_control:
-    loop_var: podluck_container_bind_name
   copy:
     content: |
       [Unit]
-      BindsTo={{ podluck_pod_name }}@{{ podluck_container_bind_name }}.service
-      After={{ podluck_pod_name }}@{{ podluck_container_bind_name }}.service
-    dest: "{{ podluck_systemd_config_dir }}/{{ podluck_pod_name }}@{{ podluck_container_name }}.service.d/bind-to-{{ podluck_container_bind_name }}.conf"
+      Wants={{ podluck_pod_name }}@{{ podluck_pod_dependency.wants }}.service
+      After={{ podluck_pod_name }}@{{ podluck_pod_dependency.wants }}.service
+      PartOf={{ podluck_pod_name }}@{{ podluck_pod_dependency.wants }}.service
+    dest: "{{ podluck_systemd_config_dir }}/{{ podluck_pod_name }}@{{ podluck_pod_dependency.container }}.service.d/wants-{{ podluck_pod_dependency.wants }}.conf"
     owner: "{{ podluck_systemd_override_file_owner | default(omit) }}"
     group: "{{ podluck_systemd_override_file_group | default(omit) }}"
     mode: "{{ podluck_systemd_override_file_mode }}"

--- a/roles/podluck_pod_systemd/tasks/pod_absent.yml
+++ b/roles/podluck_pod_systemd/tasks/pod_absent.yml
@@ -36,12 +36,9 @@
 
 - name: Podluck pod dependency absent
   register: podluck_pod_dependencies_result
-  with_dict: "{{ podluck_pod_dependencies }}"
+  loop: "{{ podluck_pod_dependencies }}"
   loop_control:
-    loop_var: podluck_pod_dependency_entry
-  vars:
-    podluck_container_name: "{{ podluck_pod_dependency_entry.key }}"
-    podluck_container_dependencies: "{{ podluck_pod_dependency_entry.value | list }}"
+    loop_var: podluck_pod_dependency
   include_tasks: dependencies_absent.yml
 
 - name: Systemd daemon reloaded

--- a/roles/podluck_pod_systemd/tasks/pod_present.yml
+++ b/roles/podluck_pod_systemd/tasks/pod_present.yml
@@ -34,12 +34,9 @@
 
 - name: Podluck pod dependency present
   register: podluck_pod_dependencies_result
-  with_dict: "{{ podluck_pod_dependencies }}"
+  loop: "{{ podluck_pod_dependencies }}"
   loop_control:
-    loop_var: podluck_pod_dependency_entry
-  vars:
-    podluck_container_name: "{{ podluck_pod_dependency_entry.key }}"
-    podluck_container_dependencies: "{{ podluck_pod_dependency_entry.value | list }}"
+    loop_var: podluck_pod_dependency
   include_tasks: dependencies_present.yml
 
 - name: Systemd daemon reloaded


### PR DESCRIPTION
Dependency type `Wants` has less strict semantics than `BindsTo`. This
will help in situations where a wanted container needs more than one
attempt to successfully start up. With `BindsTo` this could lead to the
dependent container never starting up in the first place. With `Wants`,
the dependent container will attempt to start even though the wanted
container initially failed. This should lead eventually to a working
state.

BREAKING CHANGE: Syntax of `podluck_pod_dependencies` variable changed.
Before it was a dict, now a list of objects. E.g.:

     podluck_pod_dependencies:
       -
         container: container-name
         wants: other-container-name
       -
         container: other-container-name
         wants: some-additional-container-name